### PR TITLE
TUX-2191: Add build metadata indicating bundled terraform version

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -18,8 +18,8 @@ steps:
     - TERRAGRUNT_VERSION=0.28.18
     tags:
     - latest
-    - "0.28.18"
-    - "0.28"
+    - "0.28.18_tf0.12.30"
+    - "0.28_tf0.12.30"
 
 trigger:
   event:

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 docker build \
   --build-arg TERRAFORM_VERSION=0.12.30 \
   --build-arg TERRAGRUNT_VERSION=0.28.18 \
-  -t zillownyc/terragrunt:0.28.18 \
-  -t zillownyc/terragrunt:0.28 \
+  -t zillownyc/terragrunt:0.28.18_tf0.12.30 \
+  -t zillownyc/terragrunt:0.28_tf0.12.30 \
   -t zillownyc/terragrunt:latest .
 ```


### PR DESCRIPTION
This will be necessary to support both terraform 0.12 and
terraform 0.14 etc.. using the same version of Terragrunt.